### PR TITLE
Feat/icons generator sizes from theme

### DIFF
--- a/generators/icons/src/utils/compile-icons.util.ts
+++ b/generators/icons/src/utils/compile-icons.util.ts
@@ -11,12 +11,19 @@ const createSvgrTemplate: CreateSvgrTemplate = (withReplacement) =>
 
   import React from 'react'
   import { memo } from 'react'
+  import { clsx } from 'clsx'
 
   ${withReplacement ? `import { vars } from '@ui/theme'` : ''}
 
-  export const ${componentName} = memo((props: IconProps) => (
-    ${jsx}
-  ))
+  import { iconSprinkles }  from '../icon.css.js'
+
+  export const ${componentName} = memo((props: IconProps) => {
+    const { className, style, otherProps } = iconSprinkles(props)
+
+    return (
+      ${jsx}
+    )
+})
 `
 
 export const compileIcons = async (
@@ -33,7 +40,11 @@ export const compileIcons = async (
           typescript: true,
           template: createSvgrTemplate(Boolean(replacements[icon.name])),
           plugins: ['@svgr/plugin-svgo', '@svgr/plugin-jsx', '@svgr/plugin-prettier'],
-          replaceAttrValues: replacements[icon.name] || {},
+          svgProps: {
+            className: '{clsx(className, otherProps?.className)}',
+            style: '{Object.assign({}, style, otherProps.style)}',
+          },
+          replaceAttrValues: { ...replacements[icon.name] },
         },
         { componentName: icon.name.replace('50+', 'FiftyPlus') }
       ),

--- a/ui-parts/link/src/link.component.tsx
+++ b/ui-parts/link/src/link.component.tsx
@@ -13,7 +13,7 @@ import { linkSprinkles }  from './link.css.js'
 const BaseLink = NextLink.default
 
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>((
-  { children, path, ...props },
+  { children, href, ...props },
   ref
 ) => {
   const { className, style, otherProps } = linkSprinkles(props)
@@ -21,7 +21,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>((
   return (
     <BaseLink
       ref={ref}
-      href={path}
+      href={href}
       {...otherProps}
       className={clsx(baseLinkStyles, String(otherProps?.className || ''), className)}
       style={{ ...style, ...otherProps?.style }}

--- a/ui-parts/link/src/link.interfaces.ts
+++ b/ui-parts/link/src/link.interfaces.ts
@@ -1,9 +1,9 @@
-import type { AnchorHTMLAttributes } from 'react'
+import type { LinkProps as BaseLinkProps } from 'next/link.js'
+import type { AnchorHTMLAttributes }       from 'react'
 
-import type { LinkSprinkles }        from './link.css.js'
+import type { LinkSprinkles }              from './link.css.js'
 
 export interface LinkProps
   extends LinkSprinkles,
-    Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'color'> {
-  path: string
-}
+    BaseLinkProps,
+    Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof BaseLinkProps | 'color'> {}

--- a/ui-parts/portal/package.json
+++ b/ui-parts/portal/package.json
@@ -19,8 +19,8 @@
     "react-dom": "18.2.0"
   },
   "peerDependencies": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react": "*",
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public",

--- a/ui/design/src/intro.stories.tsx
+++ b/ui/design/src/intro.stories.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
-
 import type { Meta }     from '@storybook/react'
 import type { StoryObj } from '@storybook/react'
 
@@ -54,17 +52,17 @@ const meta: Meta = {
       </Text>
       <Layout flexBasis='16px' />
       <Row gap='16px'>
-        <Link path='https://ui.atls.design'>
+        <Link href='https://ui.atls.design'>
           <Text fontSize='$medium' lineHeight='$extraMedium' color='$text.lightBlue'>
             📕 StoryBook
           </Text>
         </Link>
-        <Link path='https://github.com/atls/hyperion/wiki'>
+        <Link href='https://github.com/atls/hyperion/wiki'>
           <Text fontSize='$medium' lineHeight='$extraMedium' color='$text.lightBlue'>
             📑 Документация
           </Text>
         </Link>
-        <Link path='https://github.com/atls/hyperion/issues/new?assignees=TorinAsakura&labels=bug&template=bug.yaml'>
+        <Link href='https://github.com/atls/hyperion/issues/new?assignees=TorinAsakura&labels=bug&template=bug.yaml'>
           <Text fontSize='$medium' lineHeight='$extraMedium' color='$text.lightBlue'>
             🐛 Report bug
           </Text>

--- a/yarn.lock
+++ b/yarn.lock
@@ -788,8 +788,8 @@ __metadata:
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
   peerDependencies:
-    react: 18.2.0
-    react-dom: 18.2.0
+    react: "*"
+    react-dom: "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Resolves https://github.com/atls/hyperion/issues/585

Что сделано:
- Иконки генерируются с использованием sprinkles функции
- У `Link` компонента убран пропс `path`, заменён на `href` из пропсов `NextLink`
- Изменены версии пакетов `peerDependencies`  на `*` у `Portal`