### PR TITLE
Переиспользование Checkbox

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -993,6 +993,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@atls-ui-parts/checkbox", "workspace:ui-parts/checkbox"],\
           ["@atls-ui-parts/layout", "virtual:dbe1a421eee484ea0bdb9d0589d44d9184c9819d8f5bfcb1a73e3d85271cc45ecf4365a26e00f2a3256c13de48b40272578801688978809175001fb2693bc747#workspace:ui-parts/layout"],\
+          ["@atls-ui-parts/theme", "virtual:dbe1a421eee484ea0bdb9d0589d44d9184c9819d8f5bfcb1a73e3d85271cc45ecf4365a26e00f2a3256c13de48b40272578801688978809175001fb2693bc747#workspace:ui-parts/theme"],\
           ["@storybook/react", "virtual:90c3fa37a29dbddd012ae896ef9d136c46ca1d320faf1baf430439ab5aac7e1e7c8ef5281a72424df8d016a8c33c9d5ffe66ee23d2face19f27de3042508900f#npm:8.6.12"],\
           ["@types/react", "npm:19.1.2"],\
           ["@vanilla-extract/css", "npm:1.17.1"],\

--- a/generators/components/src/config.ts
+++ b/generators/components/src/config.ts
@@ -1,6 +1,39 @@
 import type { NodePlopAPI } from 'plop'
 
+import { copyFile }         from 'node:fs/promises'
+import { mkdir }            from 'node:fs/promises'
+import { readdir }          from 'node:fs/promises'
 import { join }             from 'node:path'
+
+const RAW_TEMPLATE_EXTENSION = '.raw'
+
+const copyRawTemplates = async (
+  sourcePath: string,
+  destinationPath: string
+): Promise<number> => {
+  const entries = await readdir(sourcePath, { withFileTypes: true })
+  const copied = 0
+
+  await mkdir(destinationPath, { recursive: true })
+
+  const copiedCounts = await Promise.all(entries.map(async (entry) => {
+    const entrySourcePath = join(sourcePath, entry.name)
+    const entryName = entry.name.endsWith(RAW_TEMPLATE_EXTENSION)
+      ? entry.name.slice(0, -RAW_TEMPLATE_EXTENSION.length)
+      : entry.name
+    const entryDestinationPath = join(destinationPath, entryName)
+
+    if (entry.isDirectory()) {
+      return copyRawTemplates(entrySourcePath, entryDestinationPath)
+    }
+
+    await copyFile(entrySourcePath, entryDestinationPath)
+
+    return 1
+  }))
+
+  return copiedCounts.reduce((total, count) => total + count, copied)
+}
 
 const generator = (plop: NodePlopAPI): void => {
   plop.setGenerator('component', {
@@ -12,6 +45,7 @@ const generator = (plop: NodePlopAPI): void => {
         message: 'Select component type:',
         choices: [
           { name: 'Bottom Navigation', value: 'bottom-navigation' },
+          { name: 'Checkbox', value: 'checkbox' },
           { name: 'Modal', value: 'modal' },
           { name: 'Popover', value: 'popover' },
           { name: 'Sidebar', value: 'sidebar' },
@@ -19,15 +53,32 @@ const generator = (plop: NodePlopAPI): void => {
         ],
       },
     ],
-    actions: (data) => [
-      {
-        type: 'addMany',
-        base: `./templates/${data?.type}`,
-        destination: join(process.cwd(), 'src'),
-        templateFiles: `./templates/${data?.type}/**/*`,
-        force: true,
-      },
-    ],
+    actions: (data) => {
+      const type = typeof data?.type === 'string' ? data.type : ''
+
+      if (type === 'checkbox') {
+        return [
+          async (): Promise<string> => {
+            const copied = await copyRawTemplates(
+              join(plop.getPlopfilePath(), 'templates', type),
+              join(process.cwd(), 'src')
+            )
+
+            return `${copied} files copied`
+          },
+        ]
+      }
+
+      return [
+        {
+          type: 'addMany',
+          base: `./templates/${type}`,
+          destination: join(process.cwd(), 'src'),
+          templateFiles: `./templates/${type}/**/*`,
+          force: true,
+        },
+      ]
+    },
   })
 }
 

--- a/generators/components/src/templates/checkbox/component.tsx.raw
+++ b/generators/components/src/templates/checkbox/component.tsx.raw
@@ -1,0 +1,29 @@
+import type { CheckboxProps }           from '@atls-ui-parts/checkbox'
+import type { ReactNode }               from 'react'
+
+import { Checkbox as BaseCheckbox }     from '@atls-ui-parts/checkbox'
+
+import { boxStyles }                    from './styles.css.js'
+import { checkIconStyles }              from './styles.css.js'
+import { checkStyles }                  from './styles.css.js'
+import { containerStyles }              from './styles.css.js'
+import { labelStyles }                  from './styles.css.js'
+
+const checkedIcon = <span className={checkIconStyles}>✓</span>
+
+export const Checkbox = ({ classNames, checkedIcon: icon = checkedIcon, ...props }: CheckboxProps): ReactNode => (
+  <BaseCheckbox
+    {...props}
+    checkedIcon={icon}
+    classNames={{
+      ...classNames,
+      box: [boxStyles, classNames?.box].filter(Boolean).join(' '),
+      check: [checkStyles, classNames?.check].filter(Boolean).join(' '),
+      container: [
+        containerStyles,
+        classNames?.container,
+      ].filter(Boolean).join(' '),
+      label: [labelStyles, classNames?.label].filter(Boolean).join(' '),
+    }}
+  />
+)

--- a/generators/components/src/templates/checkbox/index.ts.raw
+++ b/generators/components/src/templates/checkbox/index.ts.raw
@@ -1,0 +1,2 @@
+export * from './component.js'
+export type { CheckboxClassNames, CheckboxProps } from '@atls-ui-parts/checkbox'

--- a/generators/components/src/templates/checkbox/styles.css.ts.raw
+++ b/generators/components/src/templates/checkbox/styles.css.ts.raw
@@ -1,0 +1,28 @@
+import { style } from '@vanilla-extract/css'
+
+import { vars }  from '@ui/theme/theme-css'
+
+export const boxStyles = style({
+  borderColor: vars.colors.black,
+  borderRadius: 6,
+})
+
+export const checkIconStyles = style({
+  lineHeight: 1,
+})
+
+export const checkStyles = style({
+  color: vars.colors.white,
+  fontSize: 12,
+  fontWeight: 700,
+  backgroundColor: vars.colors.black,
+  borderRadius: 4,
+})
+
+export const containerStyles = style({
+  alignItems: 'center',
+})
+
+export const labelStyles = style({
+  color: vars.colors.black,
+})

--- a/ui-parts/checkbox/package.json
+++ b/ui-parts/checkbox/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@atls-ui-parts/layout": "workspace:*",
+    "@atls-ui-parts/theme": "workspace:*",
     "@storybook/react": "8.6.12",
     "@types/react": "19.1.2",
     "@vanilla-extract/css": "1.17.1",

--- a/ui-parts/checkbox/src/check/check.css.ts
+++ b/ui-parts/checkbox/src/check/check.css.ts
@@ -4,10 +4,12 @@ export const checkBaseStyles = style({
   width: 'calc(100% - 3px)',
   height: 'calc(100% - 3px)',
   display: 'none',
+  alignItems: 'center',
+  justifyContent: 'center',
   backgroundColor: 'blue',
   borderRadius: 4,
 })
 
 export const checkCheckedStyles = style({
-  display: 'block',
+  display: 'flex',
 })

--- a/ui-parts/checkbox/src/checkbox.component.tsx
+++ b/ui-parts/checkbox/src/checkbox.component.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-
+import type { KeyboardEvent }      from 'react'
+import type { MouseEvent }         from 'react'
 import type { ReactNode }          from 'react'
 
 import type { CheckboxProps }      from './checkbox.interfaces.js'
@@ -25,46 +24,98 @@ export const Checkbox = ({
   onCheck,
   children,
   active,
+  defaultActive = false,
   labelPosition = 'end',
   size = 'medium',
   color = 'blue',
   icon,
+  checkedIcon = icon,
+  className,
+  classNames,
+  onClick,
+  onKeyDown,
   ref,
+  tabIndex,
   ...props
 }: CheckboxProps): ReactNode => {
-  const [isChecked, setIsChecked] = useState<boolean>(active)
+  const [isChecked, setIsChecked] = useState<boolean>(active ?? defaultActive)
+  const checked = active ?? isChecked
 
   useEffect(() => {
-    setIsChecked(active)
-    onCheck(active)
+    if (active !== undefined) {
+      setIsChecked(active)
+    }
   }, [active])
 
   const handleCheck = (): void => {
-    setIsChecked(!isChecked)
-    onCheck(!isChecked)
+    const nextChecked = !checked
+
+    if (active === undefined) {
+      setIsChecked(nextChecked)
+    }
+
+    onCheck?.(nextChecked)
+  }
+
+  const handleClick = (event: MouseEvent<HTMLDivElement>): void => {
+    onClick?.(event)
+
+    if (!event.defaultPrevented) {
+      handleCheck()
+    }
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    onKeyDown?.(event)
+
+    if (!event.defaultPrevented && event.key === ' ') {
+      event.preventDefault()
+      handleCheck()
+    }
   }
 
   return (
     <div
-      ref={ref}
-      className={clsx(containerBaseStyles, containerPositionStyles[labelPosition])}
-      onClick={handleCheck}
       {...props}
+      ref={ref}
+      role='checkbox'
+      aria-checked={checked}
+      tabIndex={tabIndex ?? 0}
+      className={clsx(
+        containerBaseStyles,
+        containerPositionStyles[labelPosition],
+        classNames?.container,
+        className
+      )}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
     >
       <input
-        className={hiddenInputStyles}
-        checked={isChecked}
+        readOnly
+        className={clsx(hiddenInputStyles, classNames?.hiddenInput)}
+        checked={checked}
+        aria-hidden='true'
+        tabIndex={-1}
         type='checkbox'
-        onChange={handleCheck}
       />
-      <div className={clsx(boxBaseStyles, boxShapeStyles[size], boxColorStyles[color])}>
-        <div className={clsx(checkBaseStyles, isChecked && checkCheckedStyles)}>{icon}</div>
+      <div
+        className={clsx(
+          boxBaseStyles,
+          boxShapeStyles[size],
+          boxColorStyles[color],
+          classNames?.box
+        )}
+      >
+        <div className={clsx(checkBaseStyles, checked && checkCheckedStyles, classNames?.check)}>
+          {checkedIcon}
+        </div>
       </div>
       <div
         className={clsx(
           labelShapeStyles,
           labelAppearanceStyles,
-          labelPositionStyles[labelPosition]
+          labelPositionStyles[labelPosition],
+          classNames?.label
         )}
       >
         {children}

--- a/ui-parts/checkbox/src/checkbox.interfaces.ts
+++ b/ui-parts/checkbox/src/checkbox.interfaces.ts
@@ -2,9 +2,20 @@ import type { HTMLAttributes } from 'react'
 import type { Ref }            from 'react'
 import type { ReactNode }      from 'react'
 
+export interface CheckboxClassNames {
+  box?: string
+  check?: string
+  container?: string
+  hiddenInput?: string
+  label?: string
+}
+
 export interface CheckboxProps extends HTMLAttributes<HTMLDivElement> {
-  onCheck: (checked: boolean) => void
-  active: boolean
+  active?: boolean
+  checkedIcon?: ReactNode
+  classNames?: CheckboxClassNames
+  defaultActive?: boolean
+  onCheck?: (checked: boolean) => void
   labelPosition?: 'bottom' | 'end' | 'start' | 'top'
   size?: 'large' | 'medium' | 'small'
   color?: 'blue' | 'green' | 'red'

--- a/ui-parts/checkbox/stories/checkbox.stories.tsx
+++ b/ui-parts/checkbox/stories/checkbox.stories.tsx
@@ -8,6 +8,11 @@ import { Layout }             from '@atls-ui-parts/layout'
 
 import { Checkbox }           from '../src/checkbox.component.js'
 
+import { customBoxStyles }       from './styles.css.js'
+import { customCheckStyles }     from './styles.css.js'
+import { customContainerStyles } from './styles.css.js'
+import { customLabelStyles }     from './styles.css.js'
+
 const meta: Meta<CheckboxProps> = {
   title: 'Components/Checkbox',
   render: (props) => (
@@ -58,5 +63,23 @@ export const Base: Story = {
     size: 'medium',
     color: 'blue',
     children: 'Checkbox Label',
+  },
+}
+
+export const Custom: Story = {
+  name: 'Кастомный',
+  args: {
+    defaultActive: true,
+    labelPosition: 'end',
+    size: 'medium',
+    color: 'blue',
+    checkedIcon: '✓',
+    classNames: {
+      box: customBoxStyles,
+      check: customCheckStyles,
+      container: customContainerStyles,
+      label: customLabelStyles,
+    },
+    children: 'Custom checkbox',
   },
 }

--- a/ui-parts/checkbox/stories/styles.css.ts
+++ b/ui-parts/checkbox/stories/styles.css.ts
@@ -1,0 +1,27 @@
+import { style } from '@vanilla-extract/css'
+
+import { vars }  from '@atls-ui-parts/theme'
+
+export const customBoxStyles = style({
+  borderColor: vars.colors.black,
+  borderRadius: 6,
+})
+
+export const customCheckStyles = style({
+  color: vars.colors.white,
+  fontSize: 12,
+  fontWeight: 700,
+  backgroundColor: vars.colors.black,
+  borderRadius: 4,
+})
+
+export const customContainerStyles = style({
+  padding: '8px 12px',
+  border: `1px solid ${vars.colors['text.lightGray']}`,
+  borderRadius: 8,
+})
+
+export const customLabelStyles = style({
+  color: vars.colors.black,
+  fontWeight: 600,
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,6 +486,7 @@ __metadata:
   resolution: "@atls-ui-parts/checkbox@workspace:ui-parts/checkbox"
   dependencies:
     "@atls-ui-parts/layout": "workspace:*"
+    "@atls-ui-parts/theme": "workspace:*"
     "@storybook/react": "npm:8.6.12"
     "@types/react": "npm:19.1.2"
     "@vanilla-extract/css": "npm:1.17.1"


### PR DESCRIPTION
## Таска
- Close atls/hyperion#646

## Как проверять
### До фикса
1. Контекст: `@atls-ui-parts/checkbox` используется в проекте-потребителе.
Действие: попытаться передать кастомные классы для базовых частей, отдельную иконку checked-состояния или использовать компонент без внешнего `active`.
Ожидаемый результат: штатного API для переиспользования не хватает, состояние обязательно прокидывать снаружи.

2. Контекст: `@atls-ui-generators/components`.
Действие: выбрать тип компонента для генерации.
Ожидаемый результат: Checkbox отсутствует в списке.

### После фикса
1. Контекст: Storybook `Components/Checkbox / Кастомный`.
Действие: открыть story и кликнуть по Checkbox.
Ожидаемый результат: применяются кастомные классы container/box/check/label, checked-icon видна только в checked-состоянии, `aria-checked` переключается.

2. Контекст: `@atls-ui-generators/components`.
Действие: выбрать Checkbox в генераторе.
Ожидаемый результат: генерируются `component.tsx`, `index.ts`, `styles.css.ts` на базе `@atls-ui-parts/checkbox`.

## Пруфы
- `node .yarn/releases/yarn-remote.mjs workspace @atls-ui-parts/checkbox build`
- `node .yarn/releases/yarn-remote.mjs workspace @atls-ui-generators/components build`
- `node .yarn/releases/yarn-remote.mjs workspace @atls-ui-parts/design build`
- `node .yarn/releases/yarn-remote.mjs typecheck`
- `node .yarn/releases/yarn-remote.mjs lint -- ui-parts/checkbox/src/check/check.css.ts ui-parts/checkbox/src/checkbox.component.tsx ui-parts/checkbox/src/checkbox.interfaces.ts ui-parts/checkbox/stories/checkbox.stories.tsx ui-parts/checkbox/stories/styles.css.ts generators/components/src/config.ts`
- Visual smoke: `http://localhost:3001/iframe.html?viewMode=story&id=components-checkbox--custom`, click toggles `aria-checked` `true -> false`.

Примечание: полный `lint` по репозиторию сейчас падает на существующих ошибках вне этого изменения; scoped lint изменённых TS/TSX файлов зелёный.
