### PR TITLE
chore(github): add issue project automation

### DIFF
--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -1,0 +1,27 @@
+name: Add issues to project
+
+on:
+  issues:
+    types:
+      - opened
+      - transferred
+
+jobs:
+  add-to-project:
+    name: Add issue to Hyperion project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.ATLANTIS_SUPER_BOT_APP_ID }}
+          private-key: ${{ secrets.ATLANTIS_SUPER_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-issues: read
+          permission-organization-projects: write
+
+      - name: Add issue to project
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: gh project item-add 39 --owner atls --url "$ISSUE_URL"


### PR DESCRIPTION
## Таска
- Настроить добавление задач `atls/hyperion` в проект Hyperion.

## Как проверять
### Основной сценарий
1. Контекст: в `atls/hyperion` создаётся новая issue.
Действие: срабатывает workflow `Add issues to project`.
Ожидаемый результат: issue добавляется в https://github.com/orgs/atls/projects/39.

### Дополнительный сценарий
1. Контекст: в `atls/hyperion` переводят issue из другого репозитория.
Действие: срабатывает workflow `Add issues to project`.
Ожидаемый результат: transferred issue добавляется в проект Hyperion.

## Пруфы
- `actionlint .github/workflows/project.yaml`
```text
No output.
```