### PR TITLE
chore(github): allow project workflow dispatch

### DIFF
--- a/.github/workflows/project.yaml
+++ b/.github/workflows/project.yaml
@@ -5,6 +5,12 @@ on:
     types:
       - opened
       - transferred
+  workflow_dispatch:
+    inputs:
+      issue_url:
+        description: 'Issue URL to add to the project'
+        required: true
+        type: string
 
 jobs:
   add-to-project:
@@ -23,5 +29,8 @@ jobs:
       - name: Add issue to project
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          ISSUE_URL: ${{ github.event.issue.html_url }}
-        run: gh project item-add 39 --owner atls --url "$ISSUE_URL"
+          EVENT_ISSUE_URL: ${{ github.event.issue.html_url }}
+          DISPATCH_ISSUE_URL: ${{ inputs.issue_url }}
+        run: |
+          issue_url="${EVENT_ISSUE_URL:-$DISPATCH_ISSUE_URL}"
+          gh project item-add 39 --owner atls --url "$issue_url"


### PR DESCRIPTION
## Таска
- Добавить ручной запуск workflow добавления задач в проект Hyperion для проверки и повторного запуска без создания тестовых issue.

## Как проверять
### Основной сценарий
1. Контекст: workflow `Add issues to project` запускается вручную с `issue_url`.
Действие: workflow получает `ATLANTIS_SUPER_BOT` token и выполняет `gh project item-add`.
Ожидаемый результат: указанная issue находится в проекте Hyperion.

### Дополнительный сценарий
1. Контекст: в `atls/hyperion` создаётся новая issue.
Действие: срабатывает прежний `issues.opened` trigger.
Ожидаемый результат: issue добавляется в https://github.com/orgs/atls/projects/39.

## Пруфы
- `actionlint .github/workflows/project.yaml`
```text
No output.
```