### PR TITLE
fix(theme): resolve global css ESM import

### DIFF
--- a/ui-admin/theme/src/theme-css-import.test.ts
+++ b/ui-admin/theme/src/theme-css-import.test.ts
@@ -1,0 +1,20 @@
+/* eslint-disable n/no-sync */
+
+import assert            from 'node:assert/strict'
+import { readFileSync }  from 'node:fs'
+import { dirname }       from 'node:path'
+import { join }          from 'node:path'
+import { describe }      from 'node:test'
+import { it }            from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const currentDir = dirname(fileURLToPath(import.meta.url))
+
+describe('admin theme css import', () => {
+  it('should reference published global css module', () => {
+    const source = readFileSync(join(currentDir, 'theme.css.ts'), 'utf-8')
+
+    assert.match(source, /import ['"]\.\/global\.css\.js['"]/)
+    assert.doesNotMatch(source, /import ['"]\.\/global\.css['"]/)
+  })
+})

--- a/ui-admin/theme/src/theme.css.ts
+++ b/ui-admin/theme/src/theme.css.ts
@@ -1,4 +1,4 @@
-import './global.css'
+import './global.css.js'
 
 import { createTheme }         from '@vanilla-extract/css'
 import { createThemeContract } from '@vanilla-extract/css'

--- a/ui-parts/theme/src/theme-css-import.test.ts
+++ b/ui-parts/theme/src/theme-css-import.test.ts
@@ -1,0 +1,20 @@
+/* eslint-disable n/no-sync */
+
+import assert            from 'node:assert/strict'
+import { readFileSync }  from 'node:fs'
+import { dirname }       from 'node:path'
+import { join }          from 'node:path'
+import { describe }      from 'node:test'
+import { it }            from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const currentDir = dirname(fileURLToPath(import.meta.url))
+
+describe('parts theme css import', () => {
+  it('should reference published global css module', () => {
+    const source = readFileSync(join(currentDir, 'theme.css.ts'), 'utf-8')
+
+    assert.match(source, /import ['"]\.\/global\.css\.js['"]/)
+    assert.doesNotMatch(source, /import ['"]\.\/global\.css['"]/)
+  })
+})

--- a/ui-parts/theme/src/theme.css.ts
+++ b/ui-parts/theme/src/theme.css.ts
@@ -1,4 +1,4 @@
-import './global.css'
+import './global.css.js'
 
 import { createGlobalTheme } from '@vanilla-extract/css'
 


### PR DESCRIPTION
## Таска
- Close atls/hyperion#718

## Как проверять
### До фикса
1. Контекст: опубликованные npm tarball-ы `@atls-ui-parts/theme@1.1.0` и `@atls-ui-admin/theme@1.0.9`.
Действие: открыть `package/dist/theme.css.js` и проверить относительный import глобальных стилей.
Ожидаемый результат: файл импортирует `./global.css`, при этом `package/dist/global.css` в tarball отсутствует.

2. Контекст: Raijin/PnP-потребитель, который тянет визуальный стек через `@atls-ui-parts/button`.
Действие: пройти до ESM-resolution published package.
Ожидаемый результат: PnP падает на отсутствующем `@atls-ui-parts/theme/dist/global.css` до Astro/Vite.

### После фикса
1. Контекст: пакетный артефакт `@atls-ui-parts/theme`.
Действие: выполнить `yarn workspace @atls-ui-parts/theme pack --out /tmp/atls-ui-parts-theme.tgz` и проверить `package/dist/theme.css.js`.
Ожидаемый результат: tarball содержит `dist/global.css.js`, а `dist/theme.css.js` импортирует `./global.css.js`.

2. Контекст: пакетный артефакт `@atls-ui-admin/theme`.
Действие: выполнить `yarn workspace @atls-ui-admin/theme pack --out /tmp/atls-ui-admin-theme.tgz` и проверить `package/dist/theme.css.js`.
Ожидаемый результат: tarball содержит `dist/global.css.js`, а `dist/theme.css.js` импортирует `./global.css.js`.

3. Контекст: regression guard в theme-пакетах.
Действие: выполнить `yarn test unit theme-css-import.test.ts`.
Ожидаемый результат: тесты падают при возврате bare `./global.css` и проходят при `./global.css.js`.

4. Контекст: весь опубликованный Hyperion-контур.
Действие: просканировать npm tarball-ы локальных `@atls-ui*` и `@atls-utils*` пакетов на относительные ESM-ссылки, которые указывают на отсутствующие файлы.
Ожидаемый результат: тот же класс дефекта подтверждается только в `@atls-ui-parts/theme` и `@atls-ui-admin/theme`; срабатывания по template literal генераторов не считаются исполняемыми imports.

## Пруфы
- `yarn test unit theme-css-import.test.ts` — pass, 4 pass / 0 fail
- `yarn workspace @atls-ui-parts/theme build` — pass
- `yarn workspace @atls-ui-admin/theme build` — pass
- `yarn workspace @atls-ui-parts/theme lint` — pass
- `yarn workspace @atls-ui-admin/theme lint` — pass
- `yarn workspace @atls-ui-parts/theme pack --out /tmp/atls-ui-parts-theme.tgz` — pass, `dist/theme.css.js` imports `./global.css.js`
- `yarn workspace @atls-ui-admin/theme pack --out /tmp/atls-ui-admin-theme.tgz` — pass, `dist/theme.css.js` imports `./global.css.js`
- source audit: bare relative `./*.css` imports are absent after this change
- published tarball audit: missing relative ESM target exists only in `@atls-ui-parts/theme@1.1.0` and `@atls-ui-admin/theme@1.0.9`; `@atls-ui-generators/icons@1.2.2` is a template literal false positive
- `git diff --check` — pass
