### PR TITLE
fix(design): add image start scripts

### DIFF
--- a/ui-admin/design/package.json
+++ b/ui-admin/design/package.json
@@ -9,7 +9,8 @@
     "build:server": "yarn service build",
     "dev": "storybook dev --config-dir ./src -p 3002",
     "prepack": "run build",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "start-image": "node dist/index.js"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "5.2.1",

--- a/ui-admin/design/package.json
+++ b/ui-admin/design/package.json
@@ -9,7 +9,6 @@
     "build:server": "yarn service build",
     "dev": "storybook dev --config-dir ./src -p 3002",
     "prepack": "run build",
-    "start": "node dist/index.js",
     "start-image": "node dist/index.js"
   },
   "devDependencies": {

--- a/ui-parts/design/package.json
+++ b/ui-parts/design/package.json
@@ -9,7 +9,6 @@
     "build:server": "yarn service build",
     "dev": "storybook dev --config-dir ./src -p 3001",
     "prepack": "run build",
-    "start": "node dist/index.js",
     "start-image": "node dist/index.js"
   },
   "devDependencies": {

--- a/ui-parts/design/package.json
+++ b/ui-parts/design/package.json
@@ -9,7 +9,8 @@
     "build:server": "yarn service build",
     "dev": "storybook dev --config-dir ./src -p 3001",
     "prepack": "run build",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "start-image": "node dist/index.js"
   },
   "devDependencies": {
     "@atls-ui-parts/theme": "workspace:*",

--- a/ui/design/package.json
+++ b/ui/design/package.json
@@ -12,7 +12,8 @@
     "build:server": "yarn service build",
     "dev": "storybook dev --config-dir ./src -p 3000",
     "prepack": "run build",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "start-image": "node dist/index.js"
   },
   "devDependencies": {
     "@atls-ui-parts/image": "workspace:*",

--- a/ui/design/package.json
+++ b/ui/design/package.json
@@ -12,7 +12,6 @@
     "build:server": "yarn service build",
     "dev": "storybook dev --config-dir ./src -p 3000",
     "prepack": "run build",
-    "start": "node dist/index.js",
     "start-image": "node dist/index.js"
   },
   "devDependencies": {


### PR DESCRIPTION
## Таска
- Close atls/hyperion#717

## Как проверять
### До фикса
1. Контекст: post-merge Release после апгрейда Raijin, image pack для design workspace.
Действие: выполнить Release workflow для merge commit `e5381780a21df77652776bf4404ac374c3b1e14b`.
Ожидаемый результат: job падает на `@atls-ui-parts/design` с `Missing required package.json script "start-image" for launch command`.

### После фикса
1. Контекст: приватные design image workspaces.
Действие: проверить scripts в `@atls-ui-admin/design`, `@atls-ui-parts/design` и `@atls-ui/design`.
Ожидаемый результат: каждый workspace содержит `start-image: node dist/index.js` и не содержит legacy `start`.

2. Контекст: общий repo contract после апгрейда Raijin.
Действие: выполнить `yarn check`.
Ожидаемый результат: проверка проходит без ошибок.

## Пруфы
- Release failure: https://github.com/atls/hyperion/actions/runs/28058261115
- `node` script map assertion — pass, `start-image` есть и legacy `start` отсутствует
- `yarn workspaces foreach -W --from '@atls-ui-admin/design' --from '@atls-ui-parts/design' --from '@atls-ui/design' exec node -e '...'` — pass
- `yarn lint` — pass
- `yarn check` — pass до удаления legacy `start`; после удаления повторены script map assertion и `git diff --check`
- `git diff --check` — pass
