### PR TITLE
Feat/mobile colors

### DIFF
--- a/mobile/kmp/sample/src/commonMain/kotlin/com/atls/hyperion/sample/App.kt
+++ b/mobile/kmp/sample/src/commonMain/kotlin/com/atls/hyperion/sample/App.kt
@@ -1,6 +1,5 @@
 package com.atls.hyperion.sample
 
-import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import com.atls.hyperion.storybook.fragments.storybook.Storybook
 import com.atls.hyperion.ui.components.avatar.stories.AvatarStory
@@ -25,10 +24,11 @@ import com.atls.hyperion.ui.fragments.datepicker.stories.DatePickerStory
 import com.atls.hyperion.ui.fragments.datepicker.stories.DateRangePickerStory
 import com.atls.hyperion.ui.primitives.stories.LinkStory
 import com.atls.hyperion.ui.primitives.stories.TextStory
+import com.atls.hyperion.ui.theme.Theme
 
 @Composable
 fun App() {
-    MaterialTheme {
+    Theme {
         Storybook(
             components = listOf(
                 AvatarStory(),

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/avatar/styles/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/avatar/styles/appearance/Variants.kt
@@ -1,7 +1,7 @@
 package com.atls.hyperion.ui.components.avatar.styles.appearance
 
 import androidx.compose.runtime.Composable
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 @Composable
 fun AvatarAppearance.Companion.default(): AvatarAppearance =

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/bottomBar/styles/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/bottomBar/styles/appearance/Variants.kt
@@ -1,7 +1,7 @@
 package com.atls.hyperion.ui.components.bottomBar.styles.appearance
 
 import com.atls.hyperion.ui.theme.tokens.effects.Alpha
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 fun BottomBarAppearance.Companion.primary(): BottomBarAppearance =
     BottomBarAppearance(

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/button/Layout.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/button/Layout.kt
@@ -24,7 +24,7 @@ import com.atls.hyperion.ui.components.button.styles.shape.ButtonShape
 import com.atls.hyperion.ui.shared.addon.AddonPosition
 import com.atls.hyperion.ui.shared.addon.AddonSlotManager
 import com.atls.hyperion.ui.theme.tokens.layout.Elevation
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/button/styles/appearance/Colors.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/button/styles/appearance/Colors.kt
@@ -2,7 +2,7 @@ package com.atls.hyperion.ui.components.button.styles.appearance
 
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 sealed class Colors(
     val textColor: Color,

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/button/styles/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/button/styles/appearance/Variants.kt
@@ -1,42 +1,42 @@
 package com.atls.hyperion.ui.components.button.styles.appearance
 
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 import com.atls.hyperion.ui.components.button.styles.appearance.Colors as ButtonColors
 
 fun ButtonAppearance.Companion.blue(): ButtonAppearance =
     ButtonAppearance(
         default = ButtonColors.Solid(
-            backgroundColor = Colors.Button.Blue.Default.background,
-            textColor = Colors.Button.Blue.Default.font,
-            borderColor = Colors.Button.Blue.Default.border
+            backgroundColor = LegacyColors.Button.Blue.Default.background,
+            textColor = LegacyColors.Button.Blue.Default.font,
+            borderColor = LegacyColors.Button.Blue.Default.border
         ),
         pressed = ButtonColors.Solid(
-            backgroundColor = Colors.Button.Blue.Pressed.background,
-            textColor = Colors.Button.Blue.Pressed.font,
-            borderColor = Colors.Button.Blue.Pressed.border
+            backgroundColor = LegacyColors.Button.Blue.Pressed.background,
+            textColor = LegacyColors.Button.Blue.Pressed.font,
+            borderColor = LegacyColors.Button.Blue.Pressed.border
         ),
         disabled = ButtonColors.Solid(
-            backgroundColor = Colors.Button.Blue.Disabled.background,
-            textColor = Colors.Button.Blue.Disabled.font,
-            borderColor = Colors.Button.Blue.Disabled.border
+            backgroundColor = LegacyColors.Button.Blue.Disabled.background,
+            textColor = LegacyColors.Button.Blue.Disabled.font,
+            borderColor = LegacyColors.Button.Blue.Disabled.border
         )
     )
 
 fun ButtonAppearance.Companion.lightBlue(): ButtonAppearance =
     ButtonAppearance(
         default = ButtonColors.Solid(
-            backgroundColor = Colors.Button.LightBlue.Default.background,
-            textColor = Colors.Button.LightBlue.Default.font,
-            borderColor = Colors.Button.LightBlue.Default.border
+            backgroundColor = LegacyColors.Button.LightBlue.Default.background,
+            textColor = LegacyColors.Button.LightBlue.Default.font,
+            borderColor = LegacyColors.Button.LightBlue.Default.border
         ),
         pressed = ButtonColors.Solid(
-            backgroundColor = Colors.Button.LightBlue.Pressed.background,
-            textColor = Colors.Button.LightBlue.Pressed.font,
-            borderColor = Colors.Button.LightBlue.Pressed.border
+            backgroundColor = LegacyColors.Button.LightBlue.Pressed.background,
+            textColor = LegacyColors.Button.LightBlue.Pressed.font,
+            borderColor = LegacyColors.Button.LightBlue.Pressed.border
         ),
         disabled = ButtonColors.Solid(
-            backgroundColor = Colors.Button.LightBlue.Disabled.background,
-            textColor = Colors.Button.LightBlue.Disabled.font,
-            borderColor = Colors.Button.LightBlue.Disabled.border
+            backgroundColor = LegacyColors.Button.LightBlue.Disabled.background,
+            textColor = LegacyColors.Button.LightBlue.Disabled.font,
+            borderColor = LegacyColors.Button.LightBlue.Disabled.border
         )
     )

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/card/style/appearance/Appearance.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/card/style/appearance/Appearance.kt
@@ -3,7 +3,7 @@ package com.atls.hyperion.ui.components.card.style.appearance
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import com.atls.hyperion.ui.theme.tokens.layout.Elevation
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 data class CardAppearance(
     val backgroundColor: Color,

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/card/style/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/card/style/appearance/Variants.kt
@@ -1,11 +1,11 @@
 package com.atls.hyperion.ui.components.card.style.appearance
 
 import androidx.compose.runtime.Composable
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 
 @Composable
 fun CardAppearance.Companion.white(): CardAppearance =
     CardAppearance(
-        backgroundColor = Colors.Palette.white,
-        borderColor = Colors.Palette.gray
+        backgroundColor = LegacyColors.Palette.white,
+        borderColor = LegacyColors.Palette.gray
     )

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/checkbox/styles/appearance/Colors.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/checkbox/styles/appearance/Colors.kt
@@ -1,7 +1,7 @@
 package com.atls.hyperion.ui.components.checkbox.styles.appearance
 
 import androidx.compose.ui.graphics.Color
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 data class Colors(
     val backgroundColor: Color,

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/checkbox/styles/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/checkbox/styles/appearance/Variants.kt
@@ -1,6 +1,6 @@
 package com.atls.hyperion.ui.components.checkbox.styles.appearance
 
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 fun CheckboxAppearance.Companion.blue(): CheckboxAppearance =
     CheckboxAppearance(

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/divider/style/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/divider/style/appearance/Variants.kt
@@ -1,10 +1,10 @@
 package com.atls.hyperion.ui.components.divider.style.appearance
 
 import androidx.compose.runtime.Composable
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 
 @Composable
 fun DividerAppearance.Companion.default(): DividerAppearance =
     DividerAppearance(
-        color = Colors.Palette.lightPurple
+        color = LegacyColors.Palette.lightPurple
     )

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/input/Component.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/input/Component.kt
@@ -20,7 +20,7 @@ import com.atls.hyperion.ui.components.input.style.appearance.InputAppearance
 import com.atls.hyperion.ui.components.input.style.shape.InputShape
 import com.atls.hyperion.ui.shared.addon.AddonSlotManager
 import com.atls.hyperion.ui.theme.tokens.layout.Weight
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 @Composable
 fun Input(

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/input/style/appearance/Colors.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/input/style/appearance/Colors.kt
@@ -2,7 +2,7 @@ package com.atls.hyperion.ui.components.input.style.appearance
 
 import androidx.compose.ui.graphics.Color
 import com.atls.hyperion.ui.theme.tokens.colors.ColorSet
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 data class Colors(
     val backgroundColor: Color,

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/input/style/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/input/style/appearance/Variants.kt
@@ -1,7 +1,7 @@
 package com.atls.hyperion.ui.components.input.style.appearance
 
 import androidx.compose.runtime.Composable
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as TokenColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as TokenColors
 
 @Composable
 fun InputAppearance.Companion.blue(): InputAppearance =

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/list/item/style/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/list/item/style/appearance/Variants.kt
@@ -1,17 +1,17 @@
 package com.atls.hyperion.ui.components.list.item.style.appearance
 
 import androidx.compose.runtime.Composable
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 
 @Composable
 fun TextListItemAppearance.Companion.default(): TextListItemAppearance =
     TextListItemAppearance(
         selected = TextListItemAppearanceColors(
-            backgroundColor = Colors.Palette.blueProtective,
-            textColor = Colors.Text.white
+            backgroundColor = LegacyColors.Palette.blueProtective,
+            textColor = LegacyColors.Text.white
         ),
         unselected = TextListItemAppearanceColors(
-            backgroundColor = Colors.Palette.white,
-            textColor = Colors.Text.black
+            backgroundColor = LegacyColors.Palette.white,
+            textColor = LegacyColors.Text.black
         )
     )

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/list/style/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/list/style/appearance/Variants.kt
@@ -1,10 +1,10 @@
 package com.atls.hyperion.ui.components.list.style.appearance
 
 import androidx.compose.runtime.Composable
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 
 @Composable
 fun ListAppearance.Companion.default(): ListAppearance =
     ListAppearance(
-        backgroundColor = Colors.Palette.transparent
+        backgroundColor = LegacyColors.Palette.transparent
     )

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/modal/bottom/dragHandle/style/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/modal/bottom/dragHandle/style/appearance/Variants.kt
@@ -1,10 +1,10 @@
 package com.atls.hyperion.ui.components.modal.bottom.dragHandle.style.appearance
 
 import androidx.compose.runtime.Composable
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 
 @Composable
 fun DragHandleAppearance.Companion.default(): DragHandleAppearance =
     DragHandleAppearance(
-        backgroundColor = Colors.Palette.gray
+        backgroundColor = LegacyColors.Palette.gray
     )

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/modal/style/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/modal/style/appearance/Variants.kt
@@ -1,10 +1,10 @@
 package com.atls.hyperion.ui.components.modal.style.appearance
 
 import androidx.compose.runtime.Composable
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 
 @Composable
 fun ModalAppearance.Companion.default(): ModalAppearance =
     ModalAppearance(
-        backgroundColor = Colors.Palette.white
+        backgroundColor = LegacyColors.Palette.white
     )

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/pagination/style/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/pagination/style/appearance/Variants.kt
@@ -1,11 +1,11 @@
 package com.atls.hyperion.ui.components.pagination.style.appearance
 
 import androidx.compose.runtime.Composable
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 
 @Composable
 fun PaginationAppearance.Companion.default(): PaginationAppearance =
     PaginationAppearance(
-        activeColor = Colors.Palette.blueProtective,
-        disabledColor = Colors.Palette.gray
+        activeColor = LegacyColors.Palette.blueProtective,
+        disabledColor = LegacyColors.Palette.gray
     )

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/placeholder/styles/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/placeholder/styles/appearance/Variants.kt
@@ -1,18 +1,18 @@
 package com.atls.hyperion.ui.components.placeholder.styles.appearance
 
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 
 fun PlaceholderAppearance.Companion.imageBox(): PlaceholderAppearance =
     PlaceholderAppearance(
-        backgroundColor = Colors.Palette.lightPurple,
-        iconColor = Colors.Text.darkGray,
-        textColor = Colors.Text.black
+        backgroundColor = LegacyColors.Palette.lightPurple,
+        iconColor = LegacyColors.Text.darkGray,
+        textColor = LegacyColors.Text.black
 
     )
 
 fun PlaceholderAppearance.Companion.logo(): PlaceholderAppearance =
     PlaceholderAppearance(
-        backgroundColor = Colors.Palette.transparent,
-        iconColor = Colors.Text.black,
-        textColor = Colors.Text.black
+        backgroundColor = LegacyColors.Palette.transparent,
+        iconColor = LegacyColors.Text.black,
+        textColor = LegacyColors.Text.black
     )

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/progress/lib/GetBrush.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/progress/lib/GetBrush.kt
@@ -2,7 +2,7 @@ package com.atls.hyperion.ui.components.progress.lib
 
 import androidx.compose.ui.graphics.Brush
 import com.atls.hyperion.ui.components.progress.styles.appearance.Colors
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 fun getBrush(colors: Colors, index: Int): Brush? = when (colors) {
     is Colors.Single.Gradient -> colors.strokeBrush

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/progress/lib/GetSolidColor.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/progress/lib/GetSolidColor.kt
@@ -2,7 +2,7 @@ package com.atls.hyperion.ui.components.progress.lib
 
 import androidx.compose.ui.graphics.Color
 import com.atls.hyperion.ui.components.progress.styles.appearance.Colors
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 fun getSolidColor(colors: Colors, index: Int): Color = when (colors) {
     is Colors.Single.Solid -> colors.strokeColor

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/progress/stories/GradientExample.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/progress/stories/GradientExample.kt
@@ -4,7 +4,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import com.atls.hyperion.ui.components.progress.styles.appearance.Colors
 import com.atls.hyperion.ui.components.progress.styles.appearance.ProgressAppearance
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 fun ProgressAppearance.Companion.gradientExample(): ProgressAppearance =
     ProgressAppearance(

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/progress/stories/SegmentedCircle.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/progress/stories/SegmentedCircle.kt
@@ -11,7 +11,7 @@ import com.atls.hyperion.ui.components.progress.styles.shape.ProgressShape
 import com.atls.hyperion.ui.components.progress.styles.shape.default
 import com.atls.hyperion.ui.components.progress.styles.shape.thick
 import com.atls.hyperion.ui.primitives.layout.column.Column
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 @Composable
 fun SegmentedCircleProgressVariants(percent: Float) {

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/progress/stories/SegmentedLine.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/progress/stories/SegmentedLine.kt
@@ -11,7 +11,7 @@ import com.atls.hyperion.ui.components.progress.styles.appearance.primary
 import com.atls.hyperion.ui.components.progress.styles.shape.ProgressShape
 import com.atls.hyperion.ui.components.progress.styles.shape.default
 import com.atls.hyperion.ui.components.progress.styles.shape.thick
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 @Composable
 fun SegmentedLineProgressVariants(percent: Float) {

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/progress/styles/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/progress/styles/appearance/Variants.kt
@@ -1,6 +1,6 @@
 package com.atls.hyperion.ui.components.progress.styles.appearance
 
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 fun ProgressAppearance.Companion.primary(): ProgressAppearance =
     ProgressAppearance(

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/switch/styles/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/switch/styles/appearance/Variants.kt
@@ -1,6 +1,6 @@
 package com.atls.hyperion.ui.components.switch.styles.appearance
 
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 fun SwitchAppearance.Companion.default(): SwitchAppearance =
     SwitchAppearance(

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/toast/stories/Component.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/toast/stories/Component.kt
@@ -13,7 +13,7 @@ import com.atls.hyperion.ui.generated.resources.Res
 import com.atls.hyperion.ui.generated.resources.chevron_left
 import com.atls.hyperion.ui.primitives.icon.Icon
 import com.atls.hyperion.ui.primitives.icon.IconSize
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 
@@ -46,7 +46,7 @@ class ToastStories : ComponentExample {
                 leadingContent = {
                     Icon(
                         icon = painterResource(Res.drawable.chevron_left),
-                        color = Colors.Text.red,
+                        color = LegacyColors.Text.red,
                         size = IconSize.medium
                     )
                 }
@@ -61,7 +61,7 @@ class ToastStories : ComponentExample {
                 trailingContent = {
                     Icon(
                         icon = painterResource(Res.drawable.chevron_left),
-                        color = Colors.Text.red,
+                        color = LegacyColors.Text.red,
                         size = IconSize.medium
                     )
                 }
@@ -76,14 +76,14 @@ class ToastStories : ComponentExample {
                 leadingContent = {
                     Icon(
                         icon = painterResource(Res.drawable.chevron_left),
-                        color = Colors.Text.red,
+                        color = LegacyColors.Text.red,
                         size = IconSize.medium
                     )
                 },
                 trailingContent = {
                     Icon(
                         icon = painterResource(Res.drawable.chevron_left),
-                        color = Colors.Text.red,
+                        color = LegacyColors.Text.red,
                         size = IconSize.medium
                     )
                 }

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/toast/styles/appearance/Appearance.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/toast/styles/appearance/Appearance.kt
@@ -1,7 +1,7 @@
 package com.atls.hyperion.ui.components.toast.styles.appearance
 
 import androidx.compose.ui.graphics.Color
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as ThemeColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as ThemeColors
 
 data class ToastAppearance(
     val backgroundColor: Color,

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/toast/styles/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/toast/styles/appearance/Variants.kt
@@ -1,10 +1,10 @@
 package com.atls.hyperion.ui.components.toast.styles.appearance
 
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 
 fun ToastAppearance.Companion.default(): ToastAppearance =
     ToastAppearance(
-        backgroundColor = Colors.Palette.white,
-        textColor = Colors.Palette.black,
-        borderColor = Colors.Palette.gray
+        backgroundColor = LegacyColors.Palette.white,
+        textColor = LegacyColors.Palette.black,
+        borderColor = LegacyColors.Palette.gray
     )

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/tooltip/style/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/tooltip/style/appearance/Variants.kt
@@ -1,10 +1,10 @@
 package com.atls.hyperion.ui.components.tooltip.style.appearance
 
 import androidx.compose.runtime.Composable
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 
 @Composable
 fun TooltipAppearance.Companion.default() =
     TooltipAppearance(
-        backgroundColor = Colors.Palette.white
+        backgroundColor = LegacyColors.Palette.white
     )

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/tooltip/ui/TextContent.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/tooltip/ui/TextContent.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import com.atls.hyperion.ui.primitives.Text
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 import com.atls.hyperion.ui.theme.tokens.layout.Weight
 import com.atls.hyperion.ui.theme.typography.FontSize
 import com.atls.hyperion.ui.theme.typography.FontWeight
@@ -19,7 +19,7 @@ import com.atls.hyperion.ui.theme.typography.FontWeight
 fun TextTooltipContent(
     modifier: Modifier = Modifier,
     text: String,
-    color: Color = Colors.Palette.black,
+    color: Color = LegacyColors.Palette.black,
     typography: TextStyle = TextStyle(
         fontSize = FontSize.xs2,
         fontWeight = FontWeight.medium,

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/topBar/style/appearance/Variants.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/components/topBar/style/appearance/Variants.kt
@@ -1,11 +1,11 @@
 package com.atls.hyperion.ui.components.topBar.style.appearance
 
 import androidx.compose.runtime.Composable
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 
 @Composable
 fun TopBarAppearance.Companion.default(): TopBarAppearance =
     TopBarAppearance(
-        backgroundColor = Colors.Palette.transparent,
-        textColor = Colors.Text.black
+        backgroundColor = LegacyColors.Palette.transparent,
+        textColor = LegacyColors.Text.black
     )

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/fragments/datepicker/style/appearance/variants/Cell.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/fragments/datepicker/style/appearance/variants/Cell.kt
@@ -2,7 +2,7 @@ package com.atls.hyperion.ui.fragments.datepicker.style.appearance.variants
 
 import androidx.compose.runtime.Composable
 import com.atls.hyperion.ui.fragments.datepicker.style.appearance.CellAppearance
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as TokenColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as TokenColors
 
 @Composable
 fun CellAppearance.Companion.default(): CellAppearance =

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/fragments/datepicker/style/appearance/variants/Header.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/fragments/datepicker/style/appearance/variants/Header.kt
@@ -2,7 +2,7 @@ package com.atls.hyperion.ui.fragments.datepicker.style.appearance.variants
 
 import androidx.compose.runtime.Composable
 import com.atls.hyperion.ui.fragments.datepicker.style.appearance.HeaderAppearance
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as TokenColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as TokenColors
 
 @Composable
 fun HeaderAppearance.Companion.default(): HeaderAppearance =

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/fragments/datepicker/style/appearance/variants/Picker.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/fragments/datepicker/style/appearance/variants/Picker.kt
@@ -9,7 +9,7 @@ import com.atls.hyperion.ui.fragments.datepicker.style.appearance.CellAppearance
 import com.atls.hyperion.ui.fragments.datepicker.style.appearance.DatePickerAppearance
 import com.atls.hyperion.ui.fragments.datepicker.style.appearance.HeaderAppearance
 import com.atls.hyperion.ui.fragments.datepicker.style.appearance.WeekDaysAppearance
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as TokenColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as TokenColors
 
 @Composable
 fun DatePickerAppearance.Companion.default(): DatePickerAppearance =

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/fragments/datepicker/style/appearance/variants/WeekDays.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/fragments/datepicker/style/appearance/variants/WeekDays.kt
@@ -2,7 +2,7 @@ package com.atls.hyperion.ui.fragments.datepicker.style.appearance.variants
 
 import androidx.compose.runtime.Composable
 import com.atls.hyperion.ui.fragments.datepicker.style.appearance.WeekDaysAppearance
-import com.atls.hyperion.ui.theme.tokens.colors.Colors as TokenColors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors as TokenColors
 
 @Composable
 fun WeekDaysAppearance.Companion.default(): WeekDaysAppearance =

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/fragments/datepicker/ui/Day.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/fragments/datepicker/ui/Day.kt
@@ -13,7 +13,7 @@ import com.atls.hyperion.ui.fragments.datepicker.style.appearance.DatePickerAppe
 import com.atls.hyperion.ui.fragments.datepicker.style.shape.DatePickerShape
 import com.atls.hyperion.ui.primitives.Text
 import com.atls.hyperion.ui.shared.layout.aspectSquare
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 import com.kizitonwose.calendar.core.CalendarDay
 import com.kizitonwose.calendar.core.DayPosition
 import kotlinx.datetime.LocalDate
@@ -63,19 +63,19 @@ fun Day(
         .background(backgroundColor)
         .padding(shape.cellShape.padding)
         .then(
-            if ((isSelected || isRangeStart || isRangeEnd) && appearance.cellAppearance.activeBorderColor != Colors.Palette.transparent)
+            if ((isSelected || isRangeStart || isRangeEnd) && appearance.cellAppearance.activeBorderColor != LegacyColors.Palette.transparent)
                 Modifier.border(
                     shape.cellShape.borderWidth,
                     appearance.cellAppearance.activeBorderColor,
                     cellShape
                 )
-            else if (isInRange && appearance.cellAppearance.inRangeBorderColor != Colors.Palette.transparent)
+            else if (isInRange && appearance.cellAppearance.inRangeBorderColor != LegacyColors.Palette.transparent)
                 Modifier.border(
                     shape.cellShape.borderWidth,
                     appearance.cellAppearance.inRangeBorderColor,
                     cellShape
                 )
-            else if (appearance.cellAppearance.borderColor != Colors.Palette.transparent)
+            else if (appearance.cellAppearance.borderColor != LegacyColors.Palette.transparent)
                 Modifier.border(
                     shape.cellShape.borderWidth,
                     appearance.cellAppearance.borderColor,

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/primitives/stories/Link.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/primitives/stories/Link.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.text.TextStyle
 import com.atls.hyperion.storybook.shared.model.ComponentExample
 import com.atls.hyperion.ui.primitives.Link
 import com.atls.hyperion.ui.primitives.VerticalSpacer
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 import com.atls.hyperion.ui.theme.tokens.layout.Space
 import com.atls.hyperion.ui.theme.typography.FontSize
 import com.atls.hyperion.ui.theme.typography.LineHeights
@@ -24,7 +24,7 @@ class LinkStory : ComponentExample {
             Link(
                 textDecoration = "Standard Blue Link",
                 url = "https://google.com",
-                color = Colors.Text.blue,
+                color = LegacyColors.Text.blue,
                 typography = TextStyle(
                     fontSize = FontSize.md,
                     lineHeight = LineHeights.md
@@ -34,7 +34,7 @@ class LinkStory : ComponentExample {
             Link(
                 textDecoration = "Soft Blue Link",
                 url = "https://google.com",
-                color = Colors.Text.softBlue,
+                color = LegacyColors.Text.softBlue,
                 typography = TextStyle(
                     fontSize = FontSize.md,
                     lineHeight = LineHeights.md
@@ -44,7 +44,7 @@ class LinkStory : ComponentExample {
             Link(
                 textDecoration = "Small Gray Link",
                 url = "https://google.com",
-                color = Colors.Text.gray,
+                color = LegacyColors.Text.gray,
                 typography = TextStyle(
                     fontSize = FontSize.xs,
                     lineHeight = LineHeights.xs

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/primitives/stories/Text.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/primitives/stories/Text.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.text.TextStyle
 import com.atls.hyperion.storybook.shared.model.ComponentExample
 import com.atls.hyperion.ui.primitives.Text
 import com.atls.hyperion.ui.primitives.VerticalSpacer
-import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.LegacyColors
 import com.atls.hyperion.ui.theme.tokens.layout.Space
 import com.atls.hyperion.ui.theme.typography.FontSize
 import com.atls.hyperion.ui.theme.typography.LineHeights
@@ -23,7 +23,7 @@ class TextStory : ComponentExample {
         ) {
             Text(
                 text = "Heading XL",
-                color = Colors.Text.black,
+                color = LegacyColors.Text.black,
                 typography = TextStyle(
                     fontSize = FontSize.xl4,
                     lineHeight = LineHeights.xl4
@@ -32,7 +32,7 @@ class TextStory : ComponentExample {
             VerticalSpacer(Space.sm)
             Text(
                 text = "Body Medium",
-                color = Colors.Text.almostBlack,
+                color = LegacyColors.Text.almostBlack,
                 typography = TextStyle(
                     fontSize = FontSize.md,
                     lineHeight = LineHeights.md
@@ -41,7 +41,7 @@ class TextStory : ComponentExample {
             VerticalSpacer(Space.sm)
             Text(
                 text = "Small Caption",
-                color = Colors.Text.gray,
+                color = LegacyColors.Text.gray,
                 typography = TextStyle(
                     fontSize = FontSize.xs,
                     lineHeight = LineHeights.xs
@@ -50,7 +50,7 @@ class TextStory : ComponentExample {
             VerticalSpacer(Space.sm)
             Text(
                 text = "Error Text",
-                color = Colors.Text.red,
+                color = LegacyColors.Text.red,
                 typography = TextStyle(
                     fontSize = FontSize.sm,
                     lineHeight = LineHeights.sm

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/theme/Theme.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/theme/Theme.kt
@@ -1,0 +1,21 @@
+package com.atls.hyperion.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.atls.hyperion.ui.theme.tokens.colors.Colors
+import com.atls.hyperion.ui.theme.tokens.colors.darkColors
+import com.atls.hyperion.ui.theme.tokens.colors.lightColors
+
+val LocalHyperionColors = staticCompositionLocalOf { lightColors }
+
+@Composable
+fun Theme(
+    darkTheme: Boolean = false,
+    colors: Colors = if (darkTheme) darkColors else lightColors,
+    content: @Composable () -> Unit
+) {
+    CompositionLocalProvider(LocalHyperionColors provides colors) {
+        content()
+    }
+}

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/theme/tokens/colors/Dark.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/theme/tokens/colors/Dark.kt
@@ -1,0 +1,39 @@
+package com.atls.hyperion.ui.theme.tokens.colors
+
+import androidx.compose.ui.graphics.Color
+
+val darkColors = Colors(
+    action = ActionColors(
+        base = Color(0xFF5F8FFF),
+        hover = Color(0xFF7AA7FF),
+        pressed = Color(0xFF3F74FF),
+        disabled = Color(0xFF5F8FFF),
+        subtle = Color(0xFF394A6B)
+    ),
+    surface = SurfaceColors(
+        base = Color(0xFF111111),
+        subtle = Color(0xFF171717),
+        muted = Color(0xFF1F1F1F),
+        soft = Color(0xFFFFFFFF),
+        inverse = Color(0xFFF8F9FF)
+    ),
+    text = TextColors(
+        primary = Color(0xFFF2F4F7),
+        secondary = Color(0xFFC9D0DA),
+        tertiary = Color(0xFF9AA3B2),
+        muted = Color(0xFF6B7485),
+        inverse = Color(0xFF121417)
+    ),
+    status = StatusColors(
+        success = Color(0xFF4AD27F),
+        warning = Color(0xFFF2B84B),
+        error = Color(0xFFFF5C5C),
+        info = Color(0xFF5B8CFF)
+    ),
+    elevation = ElevationColors(
+        xs = Color(0x59000000),
+        sm = Color(0x66000000),
+        md = Color(0x73000000),
+        lg = Color(0x99000000)
+    )
+)

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/theme/tokens/colors/Interfaces.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/theme/tokens/colors/Interfaces.kt
@@ -54,3 +54,9 @@ data class ElevationColors(
     val md: Color,
     val lg: Color
 )
+
+data class ColorSet(
+    val font: Color,
+    val background: Color,
+    val border: Color,
+)

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/theme/tokens/colors/Interfaces.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/theme/tokens/colors/Interfaces.kt
@@ -1,0 +1,56 @@
+package com.atls.hyperion.ui.theme.tokens.colors
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+
+@Immutable
+data class Colors(
+    val action: ActionColors,
+    val surface: SurfaceColors,
+    val text: TextColors,
+    val status: StatusColors,
+    val elevation: ElevationColors
+)
+
+@Immutable
+data class ActionColors(
+    val base: Color,
+    val hover: Color,
+    val pressed: Color,
+    val disabled: Color,
+    val subtle: Color
+)
+
+@Immutable
+data class SurfaceColors(
+    val base: Color,
+    val subtle: Color,
+    val muted: Color,
+    val soft: Color,
+    val inverse: Color
+)
+
+@Immutable
+data class TextColors(
+    val primary: Color,
+    val secondary: Color,
+    val tertiary: Color,
+    val muted: Color,
+    val inverse: Color,
+)
+
+@Immutable
+data class StatusColors(
+    val success: Color,
+    val warning: Color,
+    val error: Color,
+    val info: Color
+)
+
+@Immutable
+data class ElevationColors(
+    val xs: Color,
+    val sm: Color,
+    val md: Color,
+    val lg: Color
+)

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/theme/tokens/colors/LegacyColors.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/theme/tokens/colors/LegacyColors.kt
@@ -2,7 +2,7 @@ package com.atls.hyperion.ui.theme.tokens.colors
 
 import androidx.compose.ui.graphics.Color
 
-object Colors {
+object LegacyColors { //TODO remove after components refactoring
     object Palette {
         val blue = Color(0xFF416DDF)
         val blueProtective = Color(0xFF1890FF)

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/theme/tokens/colors/Light.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/theme/tokens/colors/Light.kt
@@ -1,0 +1,39 @@
+package com.atls.hyperion.ui.theme.tokens.colors
+
+import androidx.compose.ui.graphics.Color
+
+val lightColors = Colors(
+    action = ActionColors(
+        base = Color(0xFF1E56C7),
+        hover = Color(0xFF1643A3),
+        pressed = Color(0xFF12357F),
+        disabled = Color(0x401E56C7),
+        subtle = Color(0xFF6B86C8)
+    ),
+    surface = SurfaceColors(
+        base = Color(0xFFF8F9FF),
+        subtle = Color(0xFFEFF1FF),
+        muted = Color(0xFFD4D8F0),
+        soft = Color(0xFFFFFFFF),
+        inverse = Color(0xFF111111)
+    ),
+    text = TextColors(
+        primary = Color(0xFF0C0F1E),
+        secondary = Color(0xFF2A3152),
+        tertiary = Color(0xFF6B7DB3),
+        muted = Color(0xFF9BA8C8),
+        inverse = Color(0xFFFFFFFF)
+    ),
+    status = StatusColors(
+        success = Color(0xFF10B981),
+        warning = Color(0xFFF59E0B),
+        error = Color(0xFFEF4444),
+        info = Color(0xFF60A5FA)
+    ),
+    elevation = ElevationColors(
+        xs = Color(0x14000000),
+        sm = Color(0x1A000000),
+        md = Color(0x1F000000),
+        lg = Color(0x4D000000)
+    )
+)

--- a/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/theme/tokens/colors/Set.kt
+++ b/mobile/kmp/ui/src/commonMain/kotlin/com/atls/hyperion/ui/theme/tokens/colors/Set.kt
@@ -1,9 +1,0 @@
-package com.atls.hyperion.ui.theme.tokens.colors
-
-import androidx.compose.ui.graphics.Color
-
-data class ColorSet(
-    val font: Color,
-    val background: Color,
-    val border: Color,
-)


### PR DESCRIPTION
## Таска

- Close https://github.com/atls/hyperion/issues/727

## Как проверять

1. Контекст: mobile KMP theme API
   Действие: собрать модуль sample для Android и iOS
   Ожидаемый результат: проект собирается, а theme API предоставляет две цветовые темы через общий Compose-провайдер

2. Контекст: использование темы в Compose
   Действие: обернуть экран в Theme с darkTheme = false или darkTheme = true и прочитать LocalHyperionColors.current
   Ожидаемый результат: для false доступны light colors, для true доступны dark colors

## Пруфы

<details>

<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/dd3816a2-b177-40b5-8d9b-cfe7df8a1eb4" />
<img width="590" height="1278" alt="IMG_7203" src="https://github.com/user-attachments/assets/e33ea9ac-0f88-4d90-ad83-fa724e773f5b" />


</details>
