### PR TITLE
Feat/web colors

### DIFF
--- a/ui-admin/theme/src/tokens/contract/colors.ts
+++ b/ui-admin/theme/src/tokens/contract/colors.ts
@@ -1,6 +1,6 @@
 export type ColorsTokens = Record<keyof typeof colorsContract, string>
 
-export const colorsContract = {
+export const legacyColorsContract = {
   blue: null,
   blueProtective: null,
   white: null,
@@ -42,3 +42,5 @@ export const colorsContract = {
 
   'icons.placeholder': null,
 }
+
+export const colorsContract = legacyColorsContract

--- a/ui-admin/theme/src/tokens/dark/colors.ts
+++ b/ui-admin/theme/src/tokens/dark/colors.ts
@@ -1,6 +1,6 @@
 import type { ColorsTokens } from '../contract/index.js'
 
-export const colors: ColorsTokens = {
+export const legacyColors: ColorsTokens = {
   blue: 'rgba(65, 109, 223, 1)',
   blueProtective: 'rgba(24, 144 ,255, 1)',
   white: 'rgba(0, 0, 0, 1)',
@@ -42,3 +42,5 @@ export const colors: ColorsTokens = {
 
   'icons.placeholder': 'rgba(104, 110, 130, 1)',
 }
+
+export const colors = legacyColors

--- a/ui-admin/theme/src/tokens/light/colors.ts
+++ b/ui-admin/theme/src/tokens/light/colors.ts
@@ -1,4 +1,4 @@
-export const colors = {
+export const legacyColors = {
   blue: 'rgba(65, 109, 223, 1)',
   blueProtective: 'rgba(24, 144 ,255, 1)',
   white: 'rgba(255, 255, 255, 1)',
@@ -40,3 +40,5 @@ export const colors = {
 
   'icons.placeholder': 'rgba(161, 170, 199, 1)',
 }
+
+export const colors = legacyColors

--- a/ui-parts/theme/src/tokens/colors.ts
+++ b/ui-parts/theme/src/tokens/colors.ts
@@ -1,4 +1,4 @@
-export const colors = {
+export const legacyColors = {
   blue: 'rgba(65, 109, 223, 1)',
   blueProtective: 'rgba(24, 144 ,255, 1)',
   white: 'rgba(255, 255, 255, 1)',
@@ -85,3 +85,5 @@ export const colors = {
   'text.softBlue': 'rgba(65, 109, 223, 1)',
   'text.green': 'rgba(52, 197, 29, 1)',
 }
+
+export const colors = legacyColors

--- a/ui/theme/src/index.ts
+++ b/ui/theme/src/index.ts
@@ -1,1 +1,2 @@
+export * from './theme.js'
 export * from './tokens/index.js'

--- a/ui/theme/src/theme.ts
+++ b/ui/theme/src/theme.ts
@@ -1,0 +1,16 @@
+import type { Colors } from './tokens/index.js'
+
+import { darkColors }  from './tokens/index.js'
+import { lightColors } from './tokens/index.js'
+
+export interface Theme {
+  colors: Colors
+}
+
+export const lightTheme: Theme = {
+  colors: lightColors,
+}
+
+export const darkTheme: Theme = {
+  colors: darkColors,
+}

--- a/ui/theme/src/tokens/colors/dark.ts
+++ b/ui/theme/src/tokens/colors/dark.ts
@@ -1,0 +1,37 @@
+import type { Colors } from './interfaces.js'
+
+export const darkColors: Colors = {
+  action: {
+    base: '#5F8FFF',
+    hover: '#7AA7FF',
+    pressed: '#3F74FF',
+    disabled: '#5F8FFF',
+    subtle: '#394A6B',
+  },
+  surface: {
+    base: '#111111',
+    subtle: '#171717',
+    muted: '#1F1F1F',
+    soft: '#FFFFFF',
+    inverse: '#F8F9FF',
+  },
+  text: {
+    primary: '#F2F4F7',
+    secondary: '#C9D0DA',
+    tertiary: '#9AA3B2',
+    muted: '#6B7485',
+    inverse: '#121417',
+  },
+  status: {
+    success: '#4AD27F',
+    warning: '#F2B84B',
+    error: '#FF5C5C',
+    info: '#5B8CFF',
+  },
+  elevation: {
+    xs: '#00000059',
+    sm: '#00000066',
+    md: '#00000073',
+    lg: '#00000099',
+  },
+}

--- a/ui/theme/src/tokens/colors/index.ts
+++ b/ui/theme/src/tokens/colors/index.ts
@@ -1,0 +1,3 @@
+export * from './dark.js'
+export type * from './interfaces.js'
+export * from './light.js'

--- a/ui/theme/src/tokens/colors/interfaces.ts
+++ b/ui/theme/src/tokens/colors/interfaces.ts
@@ -1,0 +1,45 @@
+export interface Colors {
+  action: ActionColors
+  surface: SurfaceColors
+  text: TextColors
+  status: StatusColors
+  elevation: ElevationColors
+}
+
+export interface ActionColors {
+  base: string
+  hover: string
+  pressed: string
+  disabled: string
+  subtle: string
+}
+
+export interface SurfaceColors {
+  base: string
+  subtle: string
+  muted: string
+  soft: string
+  inverse: string
+}
+
+export interface TextColors {
+  primary: string
+  secondary: string
+  tertiary: string
+  muted: string
+  inverse: string
+}
+
+export interface StatusColors {
+  success: string
+  warning: string
+  error: string
+  info: string
+}
+
+export interface ElevationColors {
+  xs: string
+  sm: string
+  md: string
+  lg: string
+}

--- a/ui/theme/src/tokens/colors/light.ts
+++ b/ui/theme/src/tokens/colors/light.ts
@@ -1,0 +1,37 @@
+import type { Colors } from './interfaces.js'
+
+export const lightColors: Colors = {
+  action: {
+    base: '#1E56C7',
+    hover: '#1643A3',
+    pressed: '#12357F',
+    disabled: '#1E56C740',
+    subtle: '#6B86C8',
+  },
+  surface: {
+    base: '#F8F9FF',
+    subtle: '#EFF1FF',
+    muted: '#D4D8F0',
+    soft: '#FFFFFF',
+    inverse: '#111111',
+  },
+  text: {
+    primary: '#0C0F1E',
+    secondary: '#2A3152',
+    tertiary: '#6B7DB3',
+    muted: '#9BA8C8',
+    inverse: '#FFFFFF',
+  },
+  status: {
+    success: '#10B981',
+    warning: '#F59E0B',
+    error: '#EF4444',
+    info: '#60A5FA',
+  },
+  elevation: {
+    xs: '#00000014',
+    sm: '#0000001A',
+    md: '#0000001F',
+    lg: '#0000004D',
+  },
+}

--- a/ui/theme/src/tokens/index.ts
+++ b/ui/theme/src/tokens/index.ts
@@ -1,4 +1,5 @@
 export * from './animations.js'
+export * from './colors/index.js'
 export * from './opacities.js'
 export * from './radii.js'
 export * from './space.js'


### PR DESCRIPTION
- Close https://github.com/atls/hyperion/issues/726

## Как проверять

1. Контекст: пакет `@atls-ui/theme`
   Действие: выполнить `yarn workspace @atls-ui/theme build`
   Ожидаемый результат: пакет собирается; из `@atls-ui/theme` доступны `lightTheme`, `darkTheme`, `Theme` и типы colors.

2. Контекст: существующие web theme-пакеты
   Действие: выполнить `yarn workspace @atls-ui-parts/theme build` и `yarn workspace @atls-ui-admin/theme build`
   Ожидаемый результат: пакеты собираются; старые `colors` / `colorsContract` остаются доступными через legacy-алиасы.

## Пруфы
<details>

<img width="1332" height="1189" alt="image" src="https://github.com/user-attachments/assets/09e9b883-f1cd-46d1-af2e-610c89a649d4" />

</details>
